### PR TITLE
refactor(chatbot): use environment variable for default model

### DIFF
--- a/netlify/functions/chatbot.ts
+++ b/netlify/functions/chatbot.ts
@@ -8,7 +8,7 @@ type ChatbotRequestBody = {
     context?: ContextEntry[];
 };
 
-const DEFAULT_MODEL = "nvidia/llama-3.1-nemotron-70b-instruct:free";
+const DEFAULT_MODEL = process.env.CHATBOT_MODEL ?? 'openrouter/free';
 const DEFAULT_SYSTEM_PROMPT = `You are the AI assistant for Edward Whitehead.
 
 Your purpose is to help visitors understand who Edward is, how he works, what he has built, and whether he is the right person to help solve their technical or business challenges.

--- a/scripts/build-knowledge.mjs
+++ b/scripts/build-knowledge.mjs
@@ -7,7 +7,7 @@ const root = process.cwd();
 const contentDir = path.join(root, 'content');
 const outputPath = path.join(root, 'public', 'chatbot-knowledge.json');
 const openRouterKey = process.env.OPENROUTER_API_KEY;
-const embeddingModel = process.env.CHATBOT_EMBEDDING_MODEL ?? 'openrouter/free';
+const embeddingModel = process.env.CHATBOT_MODEL ?? 'openrouter/free';
 const isOpenRouter = openRouterKey && !openRouterKey.startsWith('sk-or-');
 const openai = openRouterKey
   ? new OpenAI({


### PR DESCRIPTION
Update the chatbot function and knowledge build script to use the `CHATBOT_MODEL` environment variable instead of a hardcoded model string, falling back to 'openrouter/free' if not provided.